### PR TITLE
Reduce processing time

### DIFF
--- a/dooders/experiment.py
+++ b/dooders/experiment.py
@@ -8,7 +8,7 @@ from fastapi import WebSocket
 
 from dooders.sdk import strategies
 from dooders.sdk.actions import *
-from dooders.sdk.base.base_agent import BaseAgent
+from dooders.sdk.base.agent import Agent
 from dooders.sdk.core import Assemble
 from dooders.sdk.policies import *
 from dooders.sdk.surfaces import *
@@ -47,7 +47,7 @@ class Experiment:
         Print the past n log entries.
     get_object(object_id: str)
         Fetch an object by its id.
-    get_objects(object_type: str = 'BaseAgent')
+    get_objects(object_type: str = 'Agent')
         Fetch all objects of a given type.   
     """
 
@@ -135,7 +135,7 @@ class Experiment:
                 if self.experiment_id in line:
                     print(line)
 
-    def get_object(self, object_id: str) -> BaseAgent:
+    def get_object(self, object_id: str) -> Agent:
         """ 
         Fetch an object by its id.
 
@@ -146,12 +146,12 @@ class Experiment:
 
         Returns
         -------
-        BaseAgent
+        Agent
             The object with the given id.
         """
         return self.simulation.environment.get_object(object_id)
 
-    def get_objects(self, object_type: str = 'BaseAgent') -> List[BaseAgent]:
+    def get_objects(self, object_type: str = 'Agent') -> List[Agent]:
         """ 
         Get all objects of a given type.
         Returns all objects if no type is given.
@@ -163,14 +163,14 @@ class Experiment:
 
         Returns
         -------
-        List[BaseAgent]
+        List[Agent]
             A list of objects of the given type.
         """
         return self.simulation.environment.get_objects(object_type)
 
     def get_random_objects(self,
-                           object_type: str = 'BaseAgent',
-                           n: int = 1) -> List[BaseAgent]:
+                           object_type: str = 'Agent',
+                           n: int = 1) -> List[Agent]:
         """ 
         Get n random objects of a given type.
         Returns all objects if no type is given.
@@ -184,7 +184,7 @@ class Experiment:
 
         Returns
         -------
-        List[BaseAgent]
+        List[Agent]
             A list of n random objects of the given type.
         """
         object_list = self.get_objects(object_type)

--- a/dooders/sdk/base/agent.py
+++ b/dooders/sdk/base/agent.py
@@ -1,6 +1,5 @@
 import random
 from abc import ABC, abstractmethod
-from typing import Any, List
 
 from pydantic import BaseModel
 
@@ -25,25 +24,63 @@ class BaseStats(BaseModel):
 
 class Agent(ABC):
     """ 
+    Base Agent class
 
+    Parameters
+    ----------
+    id : int
+        Unique ID of the agent
+    position : tuple
+        Position of the agent
+    simulation : Simulation
+        Simulation object   
+        
+    Attributes
+    ----------
+    id : int
+        Unique ID of the agent
+    number : int
+        Number of the agent
+    age : int
+        Age of the agent    
+    generation : int
+        Generation of the agent
+    birth : int
+        Birth cycle of the agent
+    death : int
+        Death cycle of the agent
+    position : tuple
+        Position of the agent
+    status : str
+        Status of the agent
+    reproduction_count : int
+        Number of times the agent has reproduced
+    move_count : int
+        Number of times the agent has moved
+    energy_consumed : int
+        Energy consumed by the agent
+    hunger : int
+        Hunger of the agent
+    tag : str
+        Tag of the agent
+    encoded_weights : dict
+        Encoded weights of the agent
+    inference_record : dict
+        Inference record of the agent
+
+    Methods
+    -------
+    log(granularity: int, message: str, scope: str)
+        Log a message to the information object
+    step()
+        Step function of the agent
+    random
+        Random object
+    name
+        Name of the agent
     """
 
     def __init__(self, id: int, position, simulation) -> None:
-        """
-        Object Meta-Class
-
-        Args:
-            id: Unique ID for the object
-            position: Position of the object
-            simulation: Simulation object for the object
-
-        Attributes:
-            id: Unique ID for the object
-            position: Position of the object
-            simulation: Simulation object for the object
-            information: Information object for the object
-            environment: Environment object for the object
-        """
         self.simulation = simulation
         
         for attribute in BaseStats(id=id, 
@@ -56,10 +93,14 @@ class Agent(ABC):
         """ 
         Log a message to the information object
 
-        Args:
-            granularity: Granularity of the log
-            message: Message to log
-            scope: Scope of the log
+        Parameters
+        ----------
+        granularity : int
+            Granularity of the message
+        message : str
+            Message to log
+        scope : str
+            Scope of the message
         """
         cycle_number = self.simulation.time.time
 
@@ -77,20 +118,24 @@ class Agent(ABC):
 
     @abstractmethod
     def step(self) -> None:
-        pass
+        raise NotImplementedError('Agent.step() not implemented')
 
     @property
     def random(self) -> random.Random:
         """  
-        Returns:
-            Random object for the simulation
+        Returns
+        -------
+        random.Random
+            Random object
         """
         return self.simulation.random
 
     @property
     def name(self) -> str:
         """ 
-        Returns:
-            Name of the object
+        Returns
+        -------
+        str
+            Name of the agent
         """
         return self.__class__.__name__

--- a/dooders/sdk/base/agent.py
+++ b/dooders/sdk/base/agent.py
@@ -23,7 +23,7 @@ class BaseStats(BaseModel):
     inference_record: dict = {}
 
 
-class BaseAgent(ABC):
+class Agent(ABC):
     """ 
 
     """

--- a/dooders/sdk/models/arena.py
+++ b/dooders/sdk/models/arena.py
@@ -8,11 +8,16 @@ from typing import TYPE_CHECKING, Generator
 
 import networkx as nx
 from pydantic import BaseModel
+from sklearn.decomposition import PCA
+
 
 from dooders.sdk.models import Dooder
 
 if TYPE_CHECKING:
     from dooders.sdk.base.reality import BaseSimulation
+    
+
+gene_embedding = PCA(n_components=3)
 
 
 class Attributes(BaseModel):
@@ -115,6 +120,7 @@ class Arena:
         dooder = Dooder(self.simulation.generate_id(),
                         position, self.simulation)
         dooder.tag = tag
+        dooder.gene_embedding = gene_embedding
         
         return dooder
 

--- a/dooders/sdk/models/dooder.py
+++ b/dooders/sdk/models/dooder.py
@@ -10,8 +10,6 @@ from typing import TYPE_CHECKING, Any, List
 
 import numpy as np
 from pydantic import BaseModel
-from sklearn.decomposition import PCA
-from sklearn.manifold import TSNE
 
 from dooders.sdk import steps
 from dooders.sdk.base.agent import Agent
@@ -183,13 +181,13 @@ class Dooder(Agent):
                 self.log(granularity=1,
                          message="Terminated during cycle",
                          scope='Dooder')
-           
+
         self.post_step()
-                
+
     def post_step(self) -> None:
         """ 
         Post step flow for a dooder.
-        
+
         Process
         -------
         1. Update encoded weights
@@ -218,12 +216,12 @@ class Dooder(Agent):
                 return object
 
         return None
-    
+
     @property
     def get_encoded_weights(self) -> np.ndarray:
         """ 
         Get the encoded weights of the dooder.
-        
+
         Returns
         -------
         encoded_weights: np.ndarray
@@ -232,31 +230,30 @@ class Dooder(Agent):
         # PCA transform of internal model weights
         # {model_name: condensed_weight_tuple} i.e. {'Consume': (1, 132, 103)}
         weights = self.weights['Consume'][0]
-        #! check that the last layer isn't all zeros
-        layer_pca = PCA(n_components=3)
-        layer_pca.fit(weights)
-        return layer_pca.singular_values_
+        #! encode only at creation and termination?
+        embedding = self.gene_embedding.fit(weights)
+        return embedding.singular_values_
         # return [str(x) for x in layer_pca.singular_values_]
-        
+
         # tsne = TSNE(n_components=3, random_state=42, learning_rate='auto', init='random', perplexity=7)
         # encoded_weights = tsne.fit_transform(weights)
-        
+
         # final_encoding = np.mean(encoded_weights, axis=0)
-        
+
         # return [str(x) for x in final_encoding]
-   
+
     @property
     def weights(self) -> dict:
         """ 
         Get the weights of the dooder.
-        
+
         Returns
         -------
         weights: dict
             The weights of the dooder.
         """
         return self.internal_models.weights
-        
+
     @property
     def history(self) -> list:
         """ 
@@ -306,12 +303,12 @@ class Dooder(Agent):
         locations = self.simulation.environment.nearby_spaces((self.position))
 
         return Neighborhood(locations, self)
-    
+
     @property
     def state(self) -> dict:
         """ 
         Return the state of the dooder.
-        
+
         Returns
         -------
         state: dict

--- a/dooders/sdk/models/dooder.py
+++ b/dooders/sdk/models/dooder.py
@@ -14,7 +14,7 @@ from sklearn.decomposition import PCA
 from sklearn.manifold import TSNE
 
 from dooders.sdk import steps
-from dooders.sdk.base.base_agent import BaseAgent
+from dooders.sdk.base.agent import Agent
 from dooders.sdk.core import Condition
 from dooders.sdk.core.action import Action
 from dooders.sdk.core.step import Step
@@ -47,7 +47,7 @@ class MainStats(BaseModel):
     inference_record: dict
 
 
-class Dooder(BaseAgent):
+class Dooder(Agent):
     """ 
     Primary Dooder class
 

--- a/dooders/sdk/models/environment.py
+++ b/dooders/sdk/models/environment.py
@@ -5,7 +5,7 @@ Represents the "physical" environment in which the agents interact.
 """
 from typing import Any, List, Union
 
-from dooders.sdk.base.base_agent import BaseAgent
+from dooders.sdk.base.agent import Agent
 from dooders.sdk.core.surface import Surface
 
 
@@ -18,19 +18,19 @@ class Environment:
 
     Methods
     -------
-    place_object(object: BaseAgent, position: tuple) -> None
+    place_object(object: Agent, position: tuple) -> None
         Place an object at the provided position.
-    remove_object(object: BaseAgent) -> None
+    remove_object(object: Agent) -> None
         Remove an object from the surface.
-    move_object(object: BaseAgent, location: tuple) -> None
+    move_object(object: Agent, location: tuple) -> None
         Move an object to a new location.
-    get_object_types() -> List[BaseAgent]
+    get_object_types() -> List[Agent]
         Get all object types in the environment.
-    get_objects(object_type: str = 'BaseAgent') -> List[BaseAgent]
+    get_objects(object_type: str = 'Agent') -> List[Agent]
         Get all objects of a given type.
-    get_object(object_id: str) -> BaseAgent
+    get_object(object_id: str) -> Agent
         Get an object by its id.
-    get_random_neighbors(object: BaseAgent, object_type: BaseAgent = 'BaseAgent') -> List[BaseAgent]
+    get_random_neighbors(object: Agent, object_type: Agent = 'Agent') -> List[Agent]
         Get all objects in the neighborhood of the given object.
     """
 
@@ -52,38 +52,38 @@ class Environment:
         """
         self.surface = Surface.build(self.SurfaceType())
 
-    def place_object(self, object: 'BaseAgent', position: tuple) -> None:
+    def place_object(self, object: 'Agent', position: tuple) -> None:
         """
         Place an object at the provided position.
 
         Parameters
         ----------
-        object: BaseAgent
+        object: Agent
             The object to place.
         position: tuple
             The location to place the object, in the form (x, y).
         """
         self.surface.add(object, position)
 
-    def remove_object(self, object: Union['BaseAgent', str]) -> None:
+    def remove_object(self, object: Union['Agent', str]) -> None:
         """
         Remove an object from the surface object.
 
         Parameters
         ----------
-        object: Union[BaseAgent, str]
+        object: Union[Agent, str]
             The object to remove. 
             Either the object itself or the object's id.
         """
         self.surface.remove(object)
 
-    def move_object(self, object: 'BaseAgent', location: tuple) -> None:
+    def move_object(self, object: 'Agent', location: tuple) -> None:
         """ 
         Move an object to a new location.
 
         Parameters
         ----------
-        object: BaseAgent
+        object: Agent
             The object to move.
         location: tuple
             The location to move the object to.
@@ -91,13 +91,13 @@ class Environment:
         self.remove_object(object)
         self.place_object(object, location)
 
-    # def get_object_types(self) -> List[BaseAgent]:
+    # def get_object_types(self) -> List[Agent]:
     #     """
     #     Get all object types in the environment.
 
     #     Returns
     #     -------
-    #     object_types: List[BaseAgent]
+    #     object_types: List[Agent]
     #         A list of all object types in the environment.
     #     """
     #     #! redo this to use the iterator instead
@@ -109,7 +109,7 @@ class Environment:
     #                     object_types.append(obj.__class__.__name__)
     #     return object_types
 
-    def get_objects(self, object_type: str = None) -> List[BaseAgent]:
+    def get_objects(self, object_type: str = None) -> List[Agent]:
         """
         Get all objects of a given type.
 
@@ -120,13 +120,13 @@ class Environment:
 
         Returns
         -------
-        objects: List[BaseAgent]
+        objects: List[Agent]
             A list of all objects of the given type.
         """
 
         yield from self.surface.contents(object_type)
 
-    def get_object(self, object_id: str) -> BaseAgent:
+    def get_object(self, object_id: str) -> Agent:
         """
         Get an object by its id.
 
@@ -138,31 +138,31 @@ class Environment:
 
         Returns
         -------
-        object: BaseAgent
+        object: Agent
             The object with the given id.
         """
         return self.surface[object_id]
 
     # def get_random_neighbors(self,
-    #                          object: 'BaseAgent',
-    #                          object_type: BaseAgent = 'BaseAgent') -> List[BaseAgent]:
+    #                          object: 'Agent',
+    #                          object_type: Agent = 'Agent') -> List[Agent]:
     #     """
     #     Get all objects in the neighborhood of the given object.
 
     #     Parameters
     #     ----------
-    #     object: BaseAgent
+    #     object: Agent
     #         The object to get the neighborhood of.
     #     object_type: str
     #         The type of object to get.
 
     #     Returns
     #     -------
-    #     objects: List[BaseAgent]
+    #     objects: List[Agent]
     #         A list of all objects in the neighborhood of the given object.
     #     """
     #     #! is this duplicative too?
-    #     if object_type == 'BaseAgent':
+    #     if object_type == 'Agent':
     #         object_type_list = self.get_object_types()
     #     else:
     #         object_type_list = [object_type]
@@ -200,7 +200,7 @@ class Environment:
 
     #     return random_neighborhoods
 
-    def get_object_count(self, object_type: str = 'BaseAgent') -> int:
+    def get_object_count(self, object_type: str = 'Agent') -> int:
         """ 
         Get the number of objects of a given type.
 

--- a/dooders/sdk/models/time.py
+++ b/dooders/sdk/models/time.py
@@ -8,7 +8,7 @@ Essentially, the order in which agents are stepped through during a cycle.
 import random
 from collections import defaultdict
 
-from dooders.sdk.base.base_agent import BaseAgent
+from dooders.sdk.base.agent import Agent
 from dooders.sdk.base.base_time import BaseTime
 
 
@@ -44,7 +44,7 @@ class Time(BaseTime):
         self.time  = 0
         self._objects = defaultdict(dict)
 
-    def add(self, object: 'BaseAgent') -> None:
+    def add(self, object: 'Agent') -> None:
         """
         Add an object to the schedule.
 
@@ -61,7 +61,7 @@ class Time(BaseTime):
 
         self._objects[object.name][object.id] = object
 
-    def remove(self, object: 'BaseAgent') -> None:
+    def remove(self, object: 'Agent') -> None:
         """
         Remove all instances of a given agent from the schedule.
 
@@ -141,7 +141,7 @@ class Time(BaseTime):
         """
         return list(self._objects[object_class].values())
 
-    def get_object(self, object_class: str, id: int) -> 'BaseAgent':
+    def get_object(self, object_class: str, id: int) -> 'Agent':
         """ 
         Returns an object of a given class with a given id.
 


### PR DESCRIPTION
## Reduce gene embedding processing time

I used cProfile to evaluate the simulation's performance. One issue is that the gene embedding step of the Dooder's step was taking a lot of time due to the PCA class from sklearn was being instantiated each step for every Dooder, every cycle.

So I moved that out of the Dooder class and instantiated once in the Arena class and assigned the instantiated PCA object to the Dooder as an attribute, at creation of the Dooder.

Now the Dooder object will fit its internal weights and stores the result. I might reduce the gene embedding to occur only at object creation and termination to reduce time further

## Optimized the Adam optimizer for the neural network

*I took the neural network from scratch code and asked chatGPT to optimize it to be more memory efficient. It wrote the pull request for me too 🙂*

### **Description**

This pull request aims to optimize memory usage in the **`Optimizer_Adam`** class by implementing the following changes:

1. Add **`__slots__`** to reduce memory overhead of object attributes.
2. Refactor the class to use a single dictionary for storing and managing cache.
3. Implement lazy cache initialization.

### **Changes**

- **`optimizer.py`**:
    - Added **`__slots__`** to the **`Optimizer_Adam`** class to limit allowed attributes and save memory.
    - Refactored the class to use a single **`cache`** dictionary for storing and managing cache, replacing individual cache attributes for each layer.
    - Updated the **`update_params`** method to initialize the cache dictionary lazily only when required.