### PR TITLE
Reduce processing time: changed gene embedding frequency

### DIFF
--- a/dooders/sdk/actions/reproduce.py
+++ b/dooders/sdk/actions/reproduce.py
@@ -49,6 +49,7 @@ def reproduce(dooderX) -> None:
             offspring = dooderX.simulation.arena._generate_dooder(
                 dooderX.position, tag = 'Offspring')
             offspring.internal_models.inherit_weights(genetics)
+            offspring.get_gene_embedding()
             offspring.simulation.arena.place_dooder(
                 offspring, offspring.position)
 

--- a/dooders/sdk/models/dooder.py
+++ b/dooders/sdk/models/dooder.py
@@ -137,8 +137,8 @@ class Dooder(Agent):
         self.simulation.arena.terminate_dooder(self)
         self.status = 'Terminated'
         self.death = self.simulation.cycles
+        self.get_gene_embedding()
         message = f"Died from {reason}"
-
         self.log(granularity=1, message=message, scope='Dooder')
 
     def death_check(self) -> None:
@@ -182,9 +182,7 @@ class Dooder(Agent):
                          message="Terminated during cycle",
                          scope='Dooder')
 
-        self.post_step()
-
-    def post_step(self) -> None:
+    def get_gene_embedding(self) -> None:
         """ 
         Post step flow for a dooder.
 


### PR DESCRIPTION
Changed the frequency of the get_gene_embedding Dooder method to happen at object creation and termination. Instead of every step.