### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/Dooders/Dooders/security/code-scanning/1](https://github.com/Dooders/Dooders/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/ci.yml` so the workflow does not inherit potentially overbroad defaults.  
Best fix here: define workflow-level permissions with `contents: read`, which is sufficient for `actions/checkout` and running tests, and does not change current functionality.

Change region:
- File: `.github/workflows/ci.yml`
- Insert `permissions:` block after the `on:` section (before `jobs:`), so it applies to all jobs unless overridden.

No imports, methods, or external definitions are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
